### PR TITLE
Fixes association conversion

### DIFF
--- a/lib/simple/sql/result/records.rb
+++ b/lib/simple/sql/result/records.rb
@@ -11,6 +11,7 @@ class ::Simple::SQL::Result::Records < ::Simple::SQL::Result
     @hash_records   = records
     @target_type    = target_type
     @pg_source_oid  = pg_source_oid
+    @associations   = []
 
     materialize
   end
@@ -54,6 +55,9 @@ class ::Simple::SQL::Result::Records < ::Simple::SQL::Result
     AssociationLoader.preload @hash_records, association,
                               host_table: host_table, schema: schema, as: as,
                               order_by: order_by, limit: limit
+
+    @associations << association
+
     materialize
   end
 
@@ -64,7 +68,7 @@ class ::Simple::SQL::Result::Records < ::Simple::SQL::Result
 
   def materialize
     records = @hash_records
-    records = RowConverter.convert_ary(records, into: @target_type) if @target_type != Hash
+    records = RowConverter.convert_row(records, associations: @associations, into: @target_type) if @target_type != Hash
     replace(records)
   end
 end

--- a/spec/simple/sql_associations_spec.rb
+++ b/spec/simple/sql_associations_spec.rb
@@ -134,6 +134,16 @@ describe "Simple::SQL::Result#preload" do
 
       expect(organizations.first.users.first).to be_a(OpenStruct)
     end
+
+    it "only touches associations, leaving non-associated hashes and arrays alone" do
+      organizations = SQL.all "SELECT id, ARRAY[10000] AS ary FROM organizations", into: OpenStruct
+      expect(organizations.first.ary).to eq([10000])
+    end
+
+    it "only touches associations, leaving non-associated hashes and arrays alone" do
+      organizations = SQL.all "SELECT id, ARRAY[10000] AS ary FROM organizations", into: :struct
+      expect(organizations.first.ary).to eq([10000])
+    end
   end
 
   describe ":order_by" do


### PR DESCRIPTION
The previous release tried to convert **all** attributes when they
are arrays (has_many) or hashes (belongs_to/has_one) associations.

Not only has this been expensive, it also has been wrong (an attribute 
which is a hash in the database should not be converted), and it failed
for some queries.

This patch amends that.