### PR TITLE
Simplify connection handling

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 $: << "lib"
 require "simple/sql"
-require "simple/store"
+#require "simple/store"
 
 SQL = Simple::SQL
 SQL.connect!

--- a/lib/simple/sql.rb
+++ b/lib/simple/sql.rb
@@ -8,7 +8,6 @@ require_relative "sql/helpers"
 require_relative "sql/result"
 require_relative "sql/config"
 require_relative "sql/logging"
-require_relative "sql/simple_transactions"
 require_relative "sql/scope"
 require_relative "sql/connection_adapter"
 require_relative "sql/connection"
@@ -20,78 +19,47 @@ module Simple
   # The Simple::SQL module
   module SQL
     extend self
+
     extend Forwardable
-    delegate [:ask, :all, :each, :exec, :locked, :print] => :connection
-    delegate [:transaction, :wait_for_notify] => :connection
+    delegate [:ask, :all, :each, :exec, :locked, :print, :transaction, :wait_for_notify] => :default_connection
 
     delegate [:logger, :logger=] => ::Simple::SQL::Logging
-
-    private
-
-    def connection
-      connector.call
-    end
-
-    # The connector attribute returns a lambda, which, when called, returns a connection
-    # object.
-    #
-    # If this seems weird: this is for interacting with ActiveRecord. To be in sync how
-    # Rails handles ActiveRecord connections (it checks it out of a connection pool when
-    # needed for the first time in a request cycle, and checks it in afterwards) we need
-    # to make sure not to keep a reference to the actual connection object around. Instead
-    # we need to be able to call a function (in that case ActiveRecord::Base.connection).
-    #
-    # In non-Rails mode the connector really is a lambda which just returns an object.
-    #
-    # In any case the connector is stored in a thread-safe fashion. This is not necessary
-    # in Rails mode (because AR::B.connection itself is thread-safe already), but in non-
-    # Rails-mode we make sure to manage one connection per thread.
-    def connector=(connector)
-      Thread.current[:"Simple::SQL.connector"] = connector
-    end
-
-    def connector
-      Thread.current[:"Simple::SQL.connector"] ||= lambda { connect_to_active_record }
-    end
-
-    def connect_to_active_record
-      return Connection.active_record_connection if defined?(ActiveRecord)
-
-      STDERR.puts <<~SQL
-        Simple::SQL works out of the box with ActiveRecord-based postgres connections, reusing the current connection.
-        To use without ActiveRecord you must connect to a database via Simple::SQL.connect!.
-      SQL
-
-      raise ArgumentError, "simple-sql: missing connection"
-    end
-
-    public
-
-    # returns a configuration hash, either from the passed in database URL,
-    # from a DATABASE_URL environment value, or from the config/database.yml
-    # file.
-    def configuration(database_url = :auto)
-      database_url = Config.determine_url if database_url == :auto
-      Config.parse_url(database_url)
-    end
 
     # connects to the database specified via the url parameter. If called
     # without argument it tries to determine a DATABASE_URL from either the
     # environment setting (DATABASE_URL) or from a config/database.yml file,
     # taking into account the RAILS_ENV and RACK_ENV settings.
-    def connect!(database_url = :auto)
-      database_url = Config.determine_url if database_url == :auto
-
-      connection = Connection.pg_connection(database_url)
-      self.connector = lambda { connection }
+    #
+    # Returns the connection object.
+    def connect(database_url = :auto)
+      Connection.create(database_url)
     end
 
-    # disconnects the current connection.
+    # -- default connection ---------------------------------------------------
+
+    DEFAULT_CONNECTION_KEY = :"Simple::SQL.default_connection"
+
+    # returns the default connection.
+    def default_connection
+      Thread.current[DEFAULT_CONNECTION_KEY] ||= connect(:auto)
+    end
+
+    # connects to the database specified via the url parameter, and sets
+    # Simple::SQL's default connection.
+    #
+    # \see connect, default_connection
+    def connect!(database_url = :auto)
+      disconnect!
+      Thread.current[DEFAULT_CONNECTION_KEY] ||= connect(database_url)
+    end
+
+    # disconnects the current default connection.
     def disconnect!
-      return unless connector
+      connection = Thread.current[DEFAULT_CONNECTION_KEY]
+      return unless connection
 
       connection.disconnect!
-      self.connector = nil
+      Thread.current[DEFAULT_CONNECTION_KEY] = nil
     end
   end
 end

--- a/lib/simple/sql/config.rb
+++ b/lib/simple/sql/config.rb
@@ -39,11 +39,11 @@ module Simple::SQL::Config
     username, password, host, port, database = abc.values_at "username", "password", "host", "port", "database"
 
     URI::Generic.build(
-      scheme: "postgres", 
-      userinfo: [ username, (":" if password), password ].join,
+      scheme: "postgres",
+      userinfo: [username, (":" if password), password].join,
       host: host || "localhost",
       port: port,
-      path: "/#{database}" 
+      path: "/#{database}"
     ).to_s
   end
 

--- a/lib/simple/sql/connection.rb
+++ b/lib/simple/sql/connection.rb
@@ -1,69 +1,31 @@
-require "pg"
-
-# private
-module Simple::SQL::Connection
-  Logging = ::Simple::SQL::Logging
-
-  def self.active_record_connection
-    ActiveRecordConnection
-  end
-
-  def self.pg_connection(database_url)
-    config = ::Simple::SQL::Config.parse_url(database_url)
-
-    Logging.info "Connecting to #{database_url}"
-
-    raw_connection = PG::Connection.new(config)
-    raw_connection.set_notice_processor { |message| Logging.info(message) }
-    PgConnection.new(raw_connection)
-  end
-
-  # A PgConnection object is built around a raw connection. It includes
-  # the ConnectionAdapter, which implements ask, all, + friends, and also
-  # includes a quiet simplistic Transaction implementation
-  class PgConnection
-    attr_reader :raw_connection
-
-    def initialize(raw_connection)
-      @raw_connection = raw_connection
-    end
-
-    def disconnect!
-      return unless @raw_connection
-
-      Logging.info "Disconnecting from database"
-      @raw_connection.close
-      @raw_connection = nil
-    end
-
-    include ::Simple::SQL::ConnectionAdapter          # all, ask, first, etc.
-    include ::Simple::SQL::SimpleTransactions         # transactions
-
-    extend Forwardable
-    delegate [:wait_for_notify] => :raw_connection    # wait_for_notify
-  end
-
-  module ActiveRecordConnection
-    extend self
-
-    extend ::Simple::SQL::ConnectionAdapter           # all, ask, first, etc.
-
-    extend Forwardable
-    delegate [:transaction] => :connection            # transactions
-    delegate [:wait_for_notify] => :raw_connection    # wait_for_notify
-
-    def raw_connection
-      ActiveRecord::Base.connection.raw_connection
-    end
-
-    def disconnect!
-      # This doesn't really disconnect. We hope ActiveRecord puts the connection
-      # back into the connection pool instead.
-      @raw_connection = nil
-    end
-
-    def connection
-      ActiveRecord::Base.connection
+# A Connection object.
+#
+# A Connection object is built around a raw connection (as created from the pg
+# ruby gem).
+#
+#
+# It includes
+# the ConnectionAdapter, which implements ask, all, + friends, and also
+# includes a quiet simplistic Transaction implementation
+class Simple::SQL::Connection
+  def self.create(database_url = :auto)
+    case database_url
+    when :auto
+      if defined?(::ActiveRecord)
+        ActiveRecordConnection.new
+      else
+        RawConnection.new Simple::SQL::Config.determine_url
+      end
+    else
+      RawConnection.new database_url
     end
   end
+
+  include Simple::SQL::ConnectionAdapter
+
+  extend Forwardable
+  delegate [:wait_for_notify] => :raw_connection
 end
+
+require_relative "connection/raw_connection"
+require_relative "connection/active_record_connection"

--- a/lib/simple/sql/connection/active_record_connection.rb
+++ b/lib/simple/sql/connection/active_record_connection.rb
@@ -1,0 +1,13 @@
+class Simple::SQL::Connection::ActiveRecordConnection < Simple::SQL::Connection
+  def initialize
+    ::ActiveRecord::Base.connection
+  end
+
+  def raw_connection
+    ::ActiveRecord::Base.connection.raw_connection
+  end
+
+  def transaction(&block)
+    ::ActiveRecord::Base.connection.transaction(&block)
+  end
+end

--- a/lib/simple/sql/connection/raw_connection.rb
+++ b/lib/simple/sql/connection/raw_connection.rb
@@ -1,14 +1,23 @@
-# private
-module Simple::SQL::SimpleTransactions
-  def tx_nesting_level
-    @tx_nesting_level ||= 0
+require "pg"
+
+class Simple::SQL::Connection::RawConnection < Simple::SQL::Connection
+  attr_reader :raw_connection
+
+  def initialize(database_url)
+    @database_url   = database_url
+    @raw_connection = PG::Connection.new(@database_url)
   end
 
-  def tx_nesting_level=(tx_nesting_level)
-    @tx_nesting_level = tx_nesting_level
+  def disconnect!
+    return unless @raw_connection
+
+    @raw_connection.finish unless @raw_connection.finished?
+    @raw_connection = nil
   end
 
   def transaction(&_block)
+    @tx_nesting_level ||= 0
+
     # Notes: by using "ensure" (as opposed to rescue) we are rolling back
     # both when an exception was raised and when a value was thrown. This
     # also means we have to track whether or not to rollback. i.e. do roll
@@ -18,12 +27,12 @@ module Simple::SQL::SimpleTransactions
     # Rolling back from inside a nested transaction would require SAVEPOINT
     # support; without the code is simpler at least :)
 
-    if tx_nesting_level == 0
+    if @tx_nesting_level == 0
       exec "BEGIN"
       tx_started = true
     end
 
-    self.tx_nesting_level += 1
+    @tx_nesting_level += 1
 
     return_value = yield
 
@@ -35,7 +44,7 @@ module Simple::SQL::SimpleTransactions
 
     return_value
   ensure
-    self.tx_nesting_level -= 1
+    @tx_nesting_level -= 1
     if tx_started && !tx_committed
       exec "ROLLBACK"
     end

--- a/lib/simple/sql/formatting.rb
+++ b/lib/simple/sql/formatting.rb
@@ -16,46 +16,10 @@ module Simple
         sql
       end
 
-      def pretty_format(sql, *args)
-        sql = if use_pg_format?
-                pg_format_sql(sql)
-              else
-                format_sql(sql)
-              end
-
-        args = args.map(&:inspect).join(", ")
-        "#{sql} w/args: #{args}"
-      end
-
       private
 
       def format_sql(sql)
         sql.gsub(/\s*\n\s*/, " ").gsub(/(\A\s+)|(\s+\z)/, "")
-      end
-
-      require "open3"
-
-      def use_pg_format?
-        return @use_pg_format unless @use_pg_format.nil?
-
-        `which pg_format`
-        if $?.exitstatus == 0
-          @use_pg_format = true
-        else
-          Simple::SQL.logger.warn "[sql] simple-sql can use pg_format for logging queries. Please see https://github.com/darold/pgFormatter"
-          @use_pg_format = false
-        end
-      end
-
-      PG_FORMAT_ARGS = "--function-case 2 --maxlength 15000 --nocomment --spaces 2 --keyword-case 2 --no-comma-end"
-
-      def pg_format_sql(sql)
-        stdin, stdout, _ = Open3.popen2("pg_format #{PG_FORMAT_ARGS} -")
-        stdin.print sql
-        stdin.close
-        formatted = stdout.read
-        stdout.close
-        formatted
       end
     end
   end

--- a/lib/simple/sql/logging.rb
+++ b/lib/simple/sql/logging.rb
@@ -87,8 +87,8 @@ module Simple
         return if sql =~ /^EXPLAIN /
 
         log_multiple_lines ::Logger::WARN, prefix: "[sql-slow]" do
-          formatted_query = Formatting.pretty_format(sql, *args)
-          query_plan = ::Simple::SQL.all "EXPLAIN ANALYZE #{sql}", *args
+          formatted_query = Formatting.format(sql, *args)
+          query_plan = ::Simple::SQL.all "EXPLAIN #{sql}", *args
 
           <<~MSG
             === slow query detected: (#{'%.3f secs' % runtime}) ===================================================================================

--- a/spec/support/004_simplecov.rb
+++ b/spec/support/004_simplecov.rb
@@ -4,10 +4,18 @@ require "simplecov"
 # care of merging these results automatically.
 SimpleCov.command_name "test:#{ENV['USE_ACTIVE_RECORD']}"
 
+USE_ACTIVE_RECORD = ENV["USE_ACTIVE_RECORD"] == "1"
+
 SimpleCov.start do
   # return true to remove src from coverage 
   add_filter do |src|
-    src.filename =~ /\/spec\//
+    next true if src.filename =~ /\/spec\//
+    next true if src.filename =~ /\/immutable\.rb/
+
+    next true if USE_ACTIVE_RECORD  && src.filename =~ /\/sql\/connection\/raw_connection\.rb/
+    next true if !USE_ACTIVE_RECORD && src.filename =~ /\/sql\/connection\/active_record_connection\.rb/
+
+    false
   end
 
   minimum_coverage 90


### PR DESCRIPTION
This PR should allow to use multiple connections; i.e. we could run a Postjob.sql connection, which differs from the default connection.