### PR TITLE
Allow activerecord version to be newer then 4.x to be compatible with …

### DIFF
--- a/simple-sql.gemspec
+++ b/simple-sql.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'digest-crc', '~> 0'
 
-  gem.add_dependency 'activerecord', '~> 4'
+  gem.add_dependency 'activerecord', '> 4'
 
   # optional gems (required by some of the parts)
 


### PR DESCRIPTION
…newer rails versions