### PR TITLE
Fixing searching for a single, non-String value

### DIFF
--- a/spec/simple/sql/search_spec.rb
+++ b/spec/simple/sql/search_spec.rb
@@ -20,8 +20,12 @@ describe "Simple::SQL.search" do
     scope.search(*args).all
   end
 
-  it "filters by one dynamic attribute and one match" do
+  it "filters by one dynamic attribute matching a String" do
     expect(search(even_str: "yes").map(&:id)).to contain_exactly(2,4,6,8,10)
+  end
+
+  it "filters by one dynamic attribute matching an Integer" do
+    expect(search(user_id_squared: 4).map(&:id)).to contain_exactly(2)
   end
 
   it "filters by one dynamic attribute and multiple matches" do


### PR DESCRIPTION
When searching for a single value we should not call .empty?. For Strings this behaves incorrectly, for non-Strings this fails.