### PR TITLE
Adds monkeypatches to disable Rails’ connection reaper.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'byebug'
+gem 'pry-byebug'
 gem 'rubocop', '~> 0.57.2'
 
 # Specify your gem's dependencies in {gemname}.gemspec

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 tests: test4 test5 test6
 
 test4:
-	SIMPLE_SQL_ACTIVERECORD_SPECS="< 5" bundle
+	SIMPLE_SQL_ACTIVERECORD_SPECS="> 4,< 5" bundle
 	rspec
 
 test5:
-	SIMPLE_SQL_ACTIVERECORD_SPECS="< 6" bundle
+	SIMPLE_SQL_ACTIVERECORD_SPECS="> 5,< 6" bundle update activerecord
 	rspec
 
 test6:
-	SIMPLE_SQL_ACTIVERECORD_SPECS="< 7" bundle
+	SIMPLE_SQL_ACTIVERECORD_SPECS="> 6,< 7" bundle update activerecord
 	rspec
 
 stats:

--- a/lib/simple/sql.rb
+++ b/lib/simple/sql.rb
@@ -12,6 +12,7 @@ require_relative "sql/config"
 require_relative "sql/logging"
 require_relative "sql/connection"
 require_relative "sql/table_print"
+require_relative "sql/monkey_patches"
 
 module Simple
   # The Simple::SQL module

--- a/lib/simple/sql/monkey_patches.rb
+++ b/lib/simple/sql/monkey_patches.rb
@@ -1,0 +1,56 @@
+# This file contains some monkey patches
+
+module Simple::SQL::MonkeyPatches
+  def self.warn(msg)
+    @@warned ||= {}
+    return if @@warned[msg]
+
+    @@warned[msg] = true
+
+    msg = <<~MSG
+      == patching notice: ======================================================================================
+      Note that simple-sql changes the behaviour of underlying gems in subtle ways:
+      #{msg}
+      ==========================================================================================================
+    MSG
+
+    STDERR.puts msg
+  end
+end
+
+case ActiveRecord.gem_version.to_s
+when /^4/
+  :nop
+when /^5.2/
+  unless defined?(ActiveRecord::ConnectionAdapters::ConnectionPool::Reaper)
+    raise "Make sure to properly require active-record first"
+  end
+
+  # Rails5 introduced a Reaper which starts a Thread which checks for unused connections. However,
+  # these threads are never cleaned up. This monkey patch disables the creation of those threads
+  # in the first place, consequently preventing leakage of threads.
+  #
+  # see see https://github.com/rails/rails/issues/33600 and related commits and issues.
+  class ActiveRecord::ConnectionAdapters::ConnectionPool::Reaper
+    def run
+      return unless frequency && frequency > 0
+      Simple::SQL::MonkeyPatches.warn "disable Reaper for all ActiveRecord connection pools, see https://github.com/rails/rails/issues/33600"
+    end
+  end
+
+when /^6/
+  unless defined?(ActiveRecord::ConnectionAdapters::ConnectionPool::Reaper)
+    raise "Make sure to properly require active-record first"
+  end
+
+  # Rails6 fixes the issue w/reapers leaking threads; by properly cleaning up these threads
+  # (or  so one hopes after looking at connection_pool.rb). However, in the interest of simple-sql
+  # being more or less ActiveRecord agnostic we disable reaping here as well. (Also, that code
+  # looks pretty complex to me).
+  class ActiveRecord::ConnectionAdapters::ConnectionPool::Reaper
+    def run
+      return unless frequency && frequency > 0
+      Simple::SQL::MonkeyPatches.warn "disable Reaper for all ActiveRecord connection pools, see https://github.com/rails/rails/issues/33600"
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ end
 ENV["RACK_ENV"] = "test"
 ENV["RAILS_ENV"] = "test"
 
-require "byebug"
+require "pry-byebug"
 require "rspec"
 
 Dir.glob("./spec/support/**/*.rb").sort.each { |path| load path }

--- a/spec/support/001_database.rb
+++ b/spec/support/001_database.rb
@@ -1,5 +1,9 @@
 # connect to the database and setup the schema
 require "active_record"
+
+# it is important to require simple-sql here to activate monkey patches
+require "simple-sql"
+
 require "yaml"
 abc = YAML.load_file("config/database.yml")
 ActiveRecord::Base.establish_connection(abc["test"])


### PR DESCRIPTION
Rails5 introduced a Reaper which starts a Thread which checks for unused connections. However,
these threads are never cleaned up. This monkey patch disables the creation of those threads
in the first place, consequently preventing leakage of threads.

Rails6 fixes the issue w/reapers leaking threads; by properly cleaning up these threads
(or  so one hopes after looking at connection_pool.rb). However, in the interest of simple-sql
being more or less ActiveRecord agnostic we disable reaping here as well. (Also, that code
looks pretty complex to me).

Note that simple-sql must be required before establishing an AR connection in order for this
to take effect.