### PR TITLE
simple-sql: estimate cost exceptions

### DIFF
--- a/lib/simple/sql/connection/scope/count_by_groups.rb
+++ b/lib/simple/sql/connection/scope/count_by_groups.rb
@@ -21,7 +21,13 @@ class Simple::SQL::Connection::Scope
     sql = order_by(nil).to_sql(pagination: false)
 
     cost = @connection.estimate_cost "SELECT MIN(#{sql_fragment}) FROM (#{sql}) sq", *args
-    raise "enumerate_groups(#{sql_fragment.inspect}) takes too much time. Make sure to create a suitable index" if cost > 10_000
+
+    # cost estimates are good, but are hard to check against a hard coded value.
+    # see https://issues.mediafellows.com/issues/75232
+    #
+    # if cost > 10_000
+    #   raise "enumerate_groups(#{sql_fragment.inspect}) takes too much time. Make sure to create a suitable index"
+    # end
 
     groups = []
     var_name = "$#{@args.count + 1}"


### PR DESCRIPTION
> The following description was loaded from https://issues.mediafellows.com/issues/75232

The "estimate_cost" check now raises, but seriously it really is hard for estimate_cost to check against a useful value, since the cost unit is not well defined.
 
see https://rollbar.com/mediafellows/V2-production/items/9781/?utm_campaign=exp_repeat_item_message&utm_medium=slack&utm_source=rollbar-notification